### PR TITLE
Add RPM packaging for Electron-build

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -51,7 +51,7 @@ win:
 portable:
   artifactName: Moebius.exe
 linux:
-  artifactName: Moebius
+  artifactName: Moebius.${ext}
   target: 
   - target: rpm
   - target: deb


### PR DESCRIPTION
This PR adds packaging for Fedora/Red Hat-based system packaging.
Tested on Fedora.