### PR TITLE
Configurable Moebius server/client port

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ npm install
 node ./server.js
 ```
 
-This will start a server with default settings. In this case a password will not be set and any value entered in the Moebius client will be accepted by the server. The server runs on port 8000, as the port can't be modified by Moebius clients this is also not configurable.
+This will start a server with default settings. In this case a password will not be set and any value entered in the Moebius client will be accepted by the server. The server runs by default on port 8000, Moebius clients can modify the port by entering the server as hostname:port 
 
 The following parameters can be set:
 
 * `--file=filename.ans` load an initial ANSI file after the server starts
-* `--passw=password` set a server password which clients need to provide to logon to the server
+* `--pass=password` set a server password which clients need to provide to logon to the server
+* `--server_port=8000` set the server port, defaults to 8000. 
 * `--web` and `--web_port=80` run the webserver for external viewing (default port: 80). This enables live preview of the canvas, the preview and SAUCE information in a browser, the URL would be http://hostname.tld:web_port
 * `--path=pathname` set a path for this server: users and webviewers would connect to hostname.tld/path
 * `--quiet=true/false` suppress console output after the server has been started

--- a/app/document/doc.js
+++ b/app/document/doc.js
@@ -346,13 +346,15 @@ class Connection extends events.EventEmitter {
             }
         });
         try {
-            const {groups} = (/(?<host>[^\/]+)\/?(?<path>[^\/]*)\/?/).exec(server);
+            const {groups} = (/(?<host>[^\/:]+):?(?<port>[\d]*)\/?(?<path>[^\/]*)\/?/).exec(server);
             this.host = groups.host;
-            this.path = groups.path;
+            this.port = groups.port;
+            this.path = groups.path;;
+            if (!this.port) this.port = 8000;
             this.web = web;
             this.queued_messages = [];
             this.ready = false;
-            this.ws = new WebSocket(`ws://${encodeURI(groups.host)}:8000/${encodeURI(groups.path)}`);
+            this.ws = new WebSocket(`ws://${encodeURI(groups.host)}:${this.port}/${encodeURI(groups.path)}`);
             this.ws.addEventListener("open", () => this.open(pass));
             this.ws.addEventListener("error", () => this.emit("unable_to_connect"));
             this.ws.addEventListener("message", (resp) => this.message(JSON.parse(resp.data)));

--- a/app/server.js
+++ b/app/server.js
@@ -183,10 +183,10 @@ class Joint {
     }
 }
 
-async function start_joint({path: server_path, file, pass = "", quiet = false} = {}) {
+async function start_joint({path: server_path, file, pass = "", quiet = false, server_port} = {}) {
     server_path = (server_path != undefined) ? server_path : path.parse(file).base;
     server_path = `/${server_path.toLowerCase()}`;
-    if (!server.address()) server.listen(8000);
+    if (!server.address()) server.listen(server_port);
     if (joints[server_path]) throw "Path already in use.";
     server_path = server_path.toLowerCase();
     joints[server_path] = new Joint({path: server_path, file, pass, quiet});

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 const server = require("./app/server");
-const argv = require("minimist")(process.argv, {default: {path: "", pass: "", file: "./server.ans", quiet: false, web: false, web_port: 80}});
+const argv = require("minimist")(process.argv, {default: {path: "", pass: "", file: "./server.ans", quiet: false, web: false, web_port: 80, server_port: 8000}});
 const express = require("express");
 const path = require("path");
 


### PR DESCRIPTION
A configurable server port allows for running multiple server instances on the same host. Clients can add a port to the server hostname seperated by a colon, eg hostname:port
